### PR TITLE
Add link to related app

### DIFF
--- a/frontend/index.tsx
+++ b/frontend/index.tsx
@@ -837,6 +837,12 @@ class CastlefallApp extends Component<{}, CastlefallState> {
             <div>client {CLIENT_VERSION}</div>
             <div>server {serverVersion}</div>
             <div><a href="https://github.com/betaveros/castlefall">PRs welcome</a></div>
+            <p>
+                Related app on{' '}
+                <a href="https://play.google.com/store/apps/details?id=glydergames.cipher.ios&hl=en_US&gl=US">Google Play</a>{' '}
+                and{' '}
+                <a href="https://apps.apple.com/us/app/shibboleth/id6472225686">App Store</a>!
+            </p>
           </aside>
         </div>
         <div>


### PR DESCRIPTION
This pull request adds a link to the Shibboleth app, which is an app that lets you play Castlefall. It's got a few new features, including emoji wordlists and having the app track called-in teams and guessed words, and mostly is an app that looks pretty. I hope you'll consider adding a link to the app!

<img width="702" alt="Screenshot 2024-01-26 at 8 06 55 PM" src="https://github.com/betaveros/castlefall/assets/4324105/91dcfd52-d17e-4962-be5c-c5b728f5273b">

This is a screenshot highlighting the added HTML in green.

Here's a link to the app: [Google Play](https://play.google.com/store/apps/details?id=glydergames.cipher.ios&hl=en_US&gl=US), [App Store](https://apps.apple.com/us/app/shibboleth/id6472225686)

Thanks a lot!
